### PR TITLE
docs: fix typos across documentation files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,20 @@
 # sa-ssdp-aws
 Solution Architecture - Secure Service Delivery Platform - AWS
 
-- [Overiew](#Overview)
+- [Overview](#Overview)
   - [Infrastructure (Choose 1)](#Infrastructure (Choose 1))
     - [1. Build with Terraform](#1.-Build-with-Terraform)
     - [2. Use existing Infrastructure](#2.-Use-existing-Infrastructure)
   - [Structure of this repo](#Structure-of-this-repo)
 - [PREPARATION](#PREPARATION)
   - [1. Clone this repo](#1.-Clone-this-repo)
-  - [2. Export AWS credentions](#2.-Export-AWS-credentions)
+  - [2. Export AWS credentials](#2.-Export-AWS-credentials)
 - [INFRASTRUCTURE](#INFRASTRUCTURE)
-  - [Build Insfrastructure using Terraform (OPTION 1)](#Build-Insfrastructure-using-Terraform (OPTION 1))
-    - [1. Deploy the Insfrastructure](3.-Deploy-the-Insfrastructure)
+  - [Build Infrastructure using Terraform (OPTION 1)](#Build-Infrastructure-using-Terraform (OPTION 1))
+    - [1. Deploy the Infrastructure](3.-Deploy-the-Infrastructure)
     - [2. Review Output & Prepare Platform deployment](#4.-Review-Output-&-Prepare-Platform-deployment)
     - [3. Create kubeconfig file](#3.-Create-kubeconfig-file)
-  - [Use Existing Insfrastructure (OPTION 2)](#Use-Existing-Insfrastructure (OPTION 2))
+  - [Use Existing Infrastructure (OPTION 2)](#Use-Existing-Infrastructure (OPTION 2))
     - [1. Collect the required infrastructure values](#1.-Collect-the-required-infrastructure-values)
     - [2. Prepare the Platform Service deployment](#2.-Prepare-the-Platform-Service-deployment)
 - [PLATFORM](#PLATFORM)
@@ -39,16 +39,16 @@ You will need to choose one of the following options:
 
 #### 1. Build with Terraform
 
-The `sa-ssdp-aws/infrastucture/` directory of this reposiory contains terraform infrastructure definitions to build out AWS resource for hosting the Secure Service Delivery Platform deployment. Once you've completed the [REQUIREMENTS](#REQUIREMENTS) section below you are ready to execute the `terraform apply` within the `infrastructure/` directory.
+The `sa-ssdp-aws/infrastructure/` directory of this repository contains terraform infrastructure definitions to build out AWS resource for hosting the Secure Service Delivery Platform deployment. Once you've completed the [REQUIREMENTS](#REQUIREMENTS) section below you are ready to execute the `terraform apply` within the `infrastructure/` directory.
 
-The terraform apply takes apprximately 13 minutes to deploy.
+The terraform apply takes approximately 13 minutes to deploy.
 
 
 #### 2. Use existing Infrastructure
 
-If you have an existing environment, or wish to build your own VPCs and EKS clusters, you may skip the terraform infrastrucure build. You will require certain inputs to deploy the platform services in `./platform/`. The commands to extract this information from AWS can be found below in XXXX.
+If you have an existing environment, or wish to build your own VPCs and EKS clusters, you may skip the terraform infrastructure build. You will require certain inputs to deploy the platform services in `./platform/`. The commands to extract this information from AWS can be found below in XXXX.
 
-*NOTE:*  Following best practices, our Vault Cluster will not be available externally, over the internall. Hene, you will need a Bastian host that can access the Vault and Consul ASGs and the EKS kubectl API, as done in the Terraform infrastructure (Option 1).
+*NOTE:*  Following best practices, our Vault Cluster will not be available externally, over the internet. Hence, you will need a bastion host that can access the Vault and Consul ASGs and the EKS kubectl API, as done in the Terraform infrastructure (Option 1).
 
 ### Structure of this repo
 ```sh
@@ -89,7 +89,7 @@ Clone this repo:
 git clone https://github.com/hashicorp/sa-ssdp-aws.git
 ```
 
-#### 2. Export AWS credentions
+#### 2. Export AWS credentials
 
 Just like the AWS CLI tool, the Terraform Provider for AWS *requires* both the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY`. Export these values, e.g.:
 
@@ -98,9 +98,9 @@ export AWS_ACCESS_KEY_ID=<aws_access_key_id>
 export AWS_SECRET_ACCESS_KEY=<aws_secret_access_key>
 ```
 
-#### 3. Generate Enterprise Licences
+#### 3. Generate Enterprise Licenses
 
-You require Enterprise Licesnes for both Vault and Consul. Save them somewhere locally, e.g.:
+You require Enterprise Licenses for both Vault and Consul. Save them somewhere locally, e.g.:
 
 ```sh
 ls -l1 ./sa-ssdp-aws/inputs
@@ -119,9 +119,9 @@ You can use terraform to build infrastructure, or use your own infrastructure. C
 
 ## PLATFORM
 
-Having deployed the Infrastructure using terraform (above) or collected the appropriate informatino from existing infrastructure (also documented above)You may now commence deployment the **PLATFORM** services: [./docs/PLATFORM.md](./docs/PLATFORM.md)
+Having deployed the Infrastructure using terraform (above) or collected the appropriate information from existing infrastructure (also documented above). You may now commence deployment the **PLATFORM** services: [./docs/PLATFORM.md](./docs/PLATFORM.md)
 
-NOTE: you may use and existing Vault deployment, or create a new Vault Enterprise cluster. Documentation for each method is available.
+NOTE: you may use an existing Vault deployment, or create a new Vault Enterprise cluster. Documentation for each method is available.
 
 ---
 

--- a/docs/INFRASTRUCTURE.md
+++ b/docs/INFRASTRUCTURE.md
@@ -2,11 +2,11 @@
 
 Choose one of the two options below.
 
-1. Build Insfrastructure using Terraform (OPTION 1)
-2. Use Existing Insfrastructure (OPTION 2)
+1. Build Infrastructure using Terraform (OPTION 1)
+2. Use Existing Infrastructure (OPTION 2)
 
 
-## Build Insfrastructure using Terraform (OPTION 1)
+## Build Infrastructure using Terraform (OPTION 1)
 
 **NOTE:** working directory: `sa-ssdp-aws/infrastructure/`
 
@@ -14,12 +14,12 @@ Choose one of the two options below.
 2. Provide AWS credentials
 3. Create Infrastructure
 4. Review output
-5. Verify infrastrucutre deployment
+5. Verify infrastructure deployment
 
 
 You may inspect the default values in the `sa-ssdp-aws/infrastructure/variables.tf` file, and overwrite these details in the `terraform.tfvars`.
 
-### 1. Deploy the Insfrastructure
+### 1. Deploy the Infrastructure
 
 ```sh
 terraform init
@@ -27,7 +27,7 @@ terraform plan
 terraform apply
 ```
 
-**NOTE:** The terraform apply takes apprximately 13 minutes to deploy.
+**NOTE:** The terraform apply takes approximately 13 minutes to deploy.
 
 ### 2. Review Output & Prepare Platform deployment
 
@@ -46,15 +46,15 @@ vpc_platform_services_public_subnets = [
 your_ip_addr = "XX.XX.XX.XX"
 ```
 
-Using the Terraform output `bastian_platsvcs_copy_licenses` string, copy the vault and consul enterprise license to the bastian host, e.g.:
+Using the Terraform output `bastian_platsvcs_copy_licenses` string, copy the vault and consul enterprise license to the bastion host, e.g.:
 
 ```sh
 scp -o 'IdentitiesOnly yes' -i '../inputs/bastian-key.pem' ../inputs/* ubuntu@ec2-54-189-161-81.us-west-2.compute.amazonaws.com:/home/ubuntu/sa-ssdp-aws/inputs/
 ```
 
-### 3. Connect to the Bastian Host
+### 3. Connect to the Bastion Host
 
-Using the credentials provided in the terraform output, connect to the bastian host. Example:
+Using the credentials provided in the terraform output, connect to the bastion host. Example:
 
 ```sh
 ssh -o 'IdentitiesOnly yes' -i '../inputs/bastian-key.pem' ubuntu@ec2-35-91-0-182.us-west-2.compute.amazonaws.com
@@ -92,17 +92,17 @@ You are now ready to deploy and configure the Secure Services Platform. Proceed 
 
 ---
 
-## Use Existing Insfrastructure (OPTION 2)
+## Use Existing Infrastructure (OPTION 2)
 
 **NOTE:** Ensure you have a bastion host that can access the Vault Cluster ASG instances and the EKS Cluster Kubenetes API.
 ### 1. Collect the required infrastructure values
 
 **NOTE:** The platform services build using terraform creates 3 VPCs and 1 EKS cluster.
-While you can create this architecture in one VPC, if you are using multiple VPCs, ensure that appropriate VPC Peering and Routes exists to reach the Consul+Vault clusters.
+While you can create this architecture in one VPC, if you are using multiple VPCs, ensure that appropriate VPC Peering and Routes exist to reach the Consul+Vault clusters.
 
 If you are building your own infrastructure you will need to collect information from that infrastructure to feed into the 'platform services' terraform deployment.
 
-The example output in the above terraform step titled '4. Review Output' is an example of what is required – the Terraform deployment is configured to provide this information about the infrastucture it creates. To deploy the platform services in the next section you will need to retrieve this information from your existing infrastrcture using the following `aws cli` commands:
+The example output in the above terraform step titled '4. Review Output' is an example of what is required – the Terraform deployment is configured to provide this information about the infrastructure it creates. To deploy the platform services in the next section you will need to retrieve this information from your existing infrastructure using the following `aws cli` commands:
 
 
 **vpc ids**
@@ -143,7 +143,7 @@ Collect the VPC Public Subnet IDs for the VPC in which you will create the Vault
 aws ec2 describe-subnets
 ```
 
-If you have many you can filters, e.g.:
+If you have many you can filter, e.g.:
 ```sh
 aws ec2 describe-subnets --filters "Name=vpc-id,Values=vpc-0a87f14b17dc9b95f"
 ```
@@ -167,9 +167,9 @@ kubectl cluster-info
 kubectl get svc
 ```
 
-### 2. Connect to your bastian host
+### 2. Connect to your bastion host
 
-Using SSH, or the AWS Systems Manager (`aws ssm start-session --target`), connect to your bastian host and locally clone the git repository used above:
+Using SSH, or the AWS Systems Manager (`aws ssm start-session --target`), connect to your bastion host and locally clone the git repository used above:
 
 ```sh
 cd ~
@@ -177,7 +177,7 @@ git clone https://github.com/hashicorp/sa-ssdp-aws.git
 cd sa-ssdp-aws
 ```
 
-Verify you have the required binaries install (listed in the REQUIREMENTS section above).
+Verify you have the required binaries installed (listed in the REQUIREMENTS section above).
 
 Install the consul-enterprise and vault enterprise binaries:
 
@@ -208,9 +208,9 @@ vpc_id                  = "vpc-0eae9dd8a08b86029"
 key_name                = "bastian-key"
 ```
 
-### 4. Copy the Licesnes
+### 4. Copy the Licenses
 
-Paste the contents of your vault licence into:
+Paste the contents of your vault license into:
 
 ```sh
 vi ../../inputs/vault.hclic

--- a/platform/consul-ent-aws/README.md
+++ b/platform/consul-ent-aws/README.md
@@ -8,7 +8,7 @@ To support a secure, production-grade deployment, this module requires a Vault C
 * Consul Connect (sidecar) Certificate Management
 * Consul Secrets Management for Consul Servers, Consul K8s agents, and Consul agents
 
-This module was developed and test with (sa-ssdp-aws-tf-vault-ent)[https://github.com/hashicorp/sa-ssdp-aws-tf-vault-ent]
+This module was developed and tested with [sa-ssdp-aws-tf-vault-ent](https://github.com/hashicorp/sa-ssdp-aws-tf-vault-ent)
 
 Configuration of the Vault Cluster requires various authentication providers, roles, and policies:
 

--- a/platform/consul-ent-aws/scripts/README.md
+++ b/platform/consul-ent-aws/scripts/README.md
@@ -3,7 +3,7 @@
 The following scripts automate the many commands required to configure Vault Ent to support Consul Ent.
 
 * `auto-setup-vault.sh` - Configure Vault with the secrets required for secure Consul operation
-* `auto-setup-consul.sh` - Confgure Vault roles and policies for Consul IAM authentication
+* `auto-setup-consul.sh` - Configure Vault roles and policies for Consul IAM authentication
 
 ## `auto-setup-vault.sh` - Requirements
 
@@ -19,7 +19,7 @@ AWS_VAULT_IAM_ROLE_ARN=<aws_vault_iam_role_arn>
 
 ## `auto-setup-consul.sh` - Requirements
 
-Run this AFTER you have created your Consul cluster - it required the IAM Role ARN output from the cluster creation.
+Run this AFTER you have created your Consul cluster - it requires the IAM Role ARN output from the cluster creation.
 
 ```sh
 AWS_ACCESS_KEY_ID=<aws_access_key_id>


### PR DESCRIPTION
## Summary

Fix spelling, grammar, and formatting issues across 4 documentation files:

- **README.md**: Fix `Overiew` → `Overview`, `credentions` → `credentials`, `Insfrastructure` → `Infrastructure`, `infrastucture` → `infrastructure`, `reposiory` → `repository`, `apprximately` → `approximately`, `infrastrucure` → `infrastructure`, `internall` → `internet`, `Hene` → `Hence`, `Bastian` → `bastion`, `Licences` → `Licenses`, `Licesnes` → `Licenses`, `informatino` → `information`, `above)You` → `above). You`, `and existing` → `an existing`
- **docs/INFRASTRUCTURE.md**: Fix `Insfrastructure` → `Infrastructure` (×5), `infrastrucutre` → `infrastructure`, `apprximately` → `approximately`, `bastian` → `bastion` (×4 in descriptive text, terraform variable names left unchanged), `infrastucture` → `infrastructure`, `infrastrcture` → `infrastructure`, `can filters` → `can filter`, `install` → `installed`, `Licesnes` → `Licenses`, `licence` → `license`, `exists` → `exist`
- **platform/consul-ent-aws/README.md**: Fix `test` → `tested`, fix broken markdown link syntax `(text)[url]` → `[text](url)`
- **platform/consul-ent-aws/scripts/README.md**: Fix `Confgure` → `Configure`, `required` → `requires`

No functional changes — documentation only.